### PR TITLE
Add ernie4.5 implementation

### DIFF
--- a/src/moe_explore/functional/mlp.py
+++ b/src/moe_explore/functional/mlp.py
@@ -4,7 +4,7 @@ import torch
 from torch.profiler import record_function
 
 from moe_explore.functional.activation import activation
-from moe_explore.router import topk_router
+from moe_explore.router import router
 from moe_explore.expert_permute import get_token_indices, expert_input_permute, expert_output_permute
 from moe_explore.triton_kernels.m_grouped_gemm import m_grouped_gemm, MGroupedGEMMParams
 from moe_explore.params import MOEParams, MLPParams
@@ -17,7 +17,7 @@ def moe_mlp_torch(
 ):
     ep: MLPParams = params.expert_params
     with record_function("router"):
-        topk_scores, topk_indices = topk_router(input, ep.router_weight, params.topk, normalize_routing=params.normalize_routing)
+        topk_scores, topk_indices = router(input, params.router_params)
         flat_expert_weights = topk_scores.view(-1, 1)
         perm_to_group_indices = get_token_indices(topk_indices, params.topk, params.num_experts)
 
@@ -50,7 +50,7 @@ def moe_mlp_grouped_gemm_fused(
     autotune_mode = None
 ):
     ep: MLPParams = params.expert_params
-    topk_scores, topk_indices = topk_router(input, ep.router_weight, params.topk, normalize_routing=params.normalize_routing)
+    topk_scores, topk_indices = router(input, params.router_params)
     perm_to_group_indices = get_token_indices(topk_indices, params.topk, params.num_experts, zero_prefix=True)
 
     up_params = MGroupedGEMMParams(
@@ -96,7 +96,7 @@ def moe_mlp_grouped_gemm(
     autotune_mode = None
 ):
     ep: MLPParams = params.expert_params
-    topk_scores, topk_indices = topk_router(input, ep.router_weight, params.topk, normalize_routing=params.normalize_routing)
+    topk_scores, topk_indices = router(input, params.router_params)
     perm_to_group_indices = expert_input_permute(input, topk_indices, num_experts=params.num_experts, topk=params.topk)
     num_tokens = input.size(0) * params.topk
     

--- a/src/moe_explore/hf_moe_reference.py
+++ b/src/moe_explore/hf_moe_reference.py
@@ -8,6 +8,8 @@ from transformers.models.olmoe.configuration_olmoe import OlmoeConfig
 from transformers.models.olmoe.modeling_olmoe import OlmoeSparseMoeBlock
 from transformers.models.qwen3_moe.configuration_qwen3_moe import Qwen3MoeConfig 
 from transformers.models.qwen3_moe.modeling_qwen3_moe import Qwen3MoeSparseMoeBlock 
+from transformers.models.ernie4_5_moe.configuration_ernie4_5_moe import Ernie4_5_MoeConfig 
+from transformers.models.ernie4_5_moe.modeling_ernie4_5_moe import Ernie4_5_MoeSparseMoeBlock 
 
 from moe_explore.params import MOEParams
 
@@ -35,7 +37,7 @@ def olmoe_forward(
 ):
     moe = Olmoe(olmoe_config).to("cuda")
     moe.init_weights(
-        params.expert_params.router_weight,
+        params.router_params.router_weight,
         params.expert_params.gate_weight,
         params.expert_params.up_weight,
         params.expert_params.down_weight
@@ -67,10 +69,46 @@ def qwen3_moe_forward(
 ):
     moe = Qwen3Moe(qwen3_config).to("cuda")
     moe.init_weights(
-        params.expert_params.router_weight,
+        params.router_params.router_weight,
         params.expert_params.gate_weight,
         params.expert_params.up_weight,
         params.expert_params.down_weight
     )
+    output, _ = moe(input)
+    return output
+
+class Ernie4_5_Moe(Ernie4_5_MoeSparseMoeBlock):
+    def __init__(self, config):
+        # NOTE: explicitly disabling shared experts for testing
+        config.moe_num_shared_experts = 0
+        super().__init__(config)
+
+    def init_weights(
+        self,
+        router_weight,
+        router_bias,
+        gate_weight,
+        up_weight,
+        down_weight
+    ):
+        self.gate.weight.data = router_weight.T
+        self.moe_statics.e_score_correction_bias.data = router_bias.unsqueeze(0)
+        for i in range(self.num_experts):
+            self.experts[i].gate_proj.weight.data = gate_weight[i].t()
+            self.experts[i].up_proj.weight.data = up_weight[i].t()
+            self.experts[i].down_proj.weight.data = down_weight[i].t()
+
+def ernie4_5_moe_forward(
+    ernie4_5_config: Ernie4_5_MoeConfig,
+    input: torch.Tensor,
+    params: MOEParams
+):
+    moe = Ernie4_5_Moe(ernie4_5_config).to("cuda")
+    moe.init_weights(
+        params.router_params.router_weight.to(torch.float32),
+        params.router_params.bias.to(torch.float32),
+        params.expert_params.gate_weight,
+        params.expert_params.up_weight,
+        params.expert_params.down_weight)
     output, _ = moe(input)
     return output

--- a/src/moe_explore/params.py
+++ b/src/moe_explore/params.py
@@ -1,30 +1,48 @@
 from moe_explore.functional.activation import Activation
 from dataclasses import dataclass
-import math
-from typing import Union, Callable, Optional
+from typing import Union, Optional
 import torch
 
 @dataclass
-class MLPParams:
-    router_weight: torch.Tensor
+class FFNParams:
+    pass
+
+@dataclass
+class MLPParams(FFNParams):
     weight1: torch.Tensor
     weight2: torch.Tensor
     activation: Activation
 
 @dataclass
-class GLUParams:
-    router_weight: torch.Tensor
+class GLUParams(FFNParams):
     gate_weight: torch.Tensor
     up_weight: torch.Tensor
     down_weight: torch.Tensor
     activation: Activation
+    
+@dataclass
+class RouterParams:
+    pass
+    
+@dataclass
+class TopkRouterParams(RouterParams):
+    router_weight: torch.Tensor
+    topk: int
+    softmax_before_topk: bool = True
+    normalize_routing: bool = False
 
 @dataclass
+class ErnieRouterParams(RouterParams):
+    router_weight: torch.Tensor
+    bias: torch.Tensor
+    topk: int
+    
+@dataclass
 class MOEParams:
-    expert_params: Union[MLPParams, GLUParams]
+    router_params: RouterParams
+    expert_params: FFNParams
     num_experts: int
     topk: int
-    normalize_routing: bool = False
 
 @dataclass
 class ExpertMatmulParams:

--- a/src/moe_explore/router.py
+++ b/src/moe_explore/router.py
@@ -1,29 +1,54 @@
 import torch
 from torch import nn
+from moe_explore.params import RouterParams, TopkRouterParams, ErnieRouterParams
 
 @torch.compile
 def softmax(x):
     return nn.functional.softmax(x, dim=-1, dtype=torch.float32)
 
-@torch.compile
+def router(input:torch.Tensor, params: RouterParams):
+    if isinstance(params, TopkRouterParams):
+        return topk_router(input, params)
+    elif isinstance(params, ErnieRouterParams):
+        return ernie_router(input, params)
+    else:
+        raise ValueError(f"Unsupported router type: {type(params)}")
+
+#@torch.compile
 def topk_router(
     input: torch.Tensor,
-    router_weight: torch.Tensor,
-    topk: int,
-    softmax_before_topk: bool = True,
-    normalize_routing: bool = False
+    router_params: TopkRouterParams
 ):
-    logits = input @ router_weight
-    if softmax_before_topk:
+    logits = input @ router_params.router_weight
+    if router_params.softmax_before_topk:
         logits = softmax(logits)
 
-    topk_scores, topk_indices = torch.topk(logits, k=topk, dim=-1, sorted=False)
+    topk_scores, topk_indices = torch.topk(logits, k=router_params.topk, dim=-1, sorted=False)
 
-    if not softmax_before_topk:
+    if not router_params.softmax_before_topk:
         topk_scores = softmax(topk_scores)
 
-    if normalize_routing:
+    if router_params.normalize_routing:
         topk_scores /= topk_scores.sum(dim=-1, keepdim=True)
 
     topk_scores = topk_scores.to(input.dtype)
     return topk_scores, topk_indices
+
+@torch.compile
+def ernie_router(
+    input: torch.Tensor,
+    router_params: ErnieRouterParams
+):
+    assert router_params.router_weight.dtype is torch.float32
+    # Ernie uses float32 for everything in the router.
+    with torch.autocast(device_type=input.device.type, enabled=False):
+        logits = input.float() @ router_params.router_weight
+        weights = softmax(logits)
+        # in huggingface, it's topk(moe_statics(weights)), but the moe_statics is just adding a bias?
+        _, topk_indices = torch.topk(weights + router_params.bias, k=router_params.topk, dim=-1, sorted=False)
+        weights = torch.gather(weights, index=topk_indices, dim=-1)
+        # The min=1e-12 is hardcoded from `moe_norm_min` in huggingface config.
+        # I assume it's just to ensure there is not a division by zero.
+        weights = weights / torch.clamp(weights.sum(dim=-1, keepdim=True), min=1e-12)
+        weights = weights.to(input.dtype)
+        return weights, topk_indices

--- a/src/moe_explore/triton_kernels/m_grouped_gemm.py
+++ b/src/moe_explore/triton_kernels/m_grouped_gemm.py
@@ -55,7 +55,7 @@ def m_grouped_gemm_inner(
     MASK_K: tl.constexpr = K % BLOCK_K != 0
     
     num_m_tiles = tl.cdiv(m, BLOCK_M)
-    num_n_tiles = tl.cdiv(N, BLOCK_N)
+    num_n_tiles: tl.constexpr = tl.cdiv(N, BLOCK_N)
     num_tiles = tl.cast(num_m_tiles * num_n_tiles, tl.int32)
     while (tile_id >= last_problem_end and tile_id < last_problem_end + num_tiles):
         tile_id_in_gemm = tile_id - last_problem_end
@@ -73,8 +73,6 @@ def m_grouped_gemm_inner(
             permute_token_indices = tl.load(permute_indices_ptr + start_idx + tile_m_offsets,
                                             mask=token_mask, 
                                             other=0)
-        
-        if GATHER_ROWS:
             token_indices = permute_token_indices // TOPK
         else:
             token_indices = start_idx + tile_m_offsets
@@ -151,8 +149,6 @@ def m_grouped_gemm_persistent_kernel(
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
-    PROLOGUE: tl.constexpr,
-    EPILOGUE: tl.constexpr
 ):
     tile_id = tl.program_id(axis=0)
     last_problem_end = 0

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -3,11 +3,6 @@ import math
 from dataclasses import dataclass
 import pytest
 import torch
-from transformers.models.olmoe.configuration_olmoe import OlmoeConfig
-from transformers.models.qwen3_moe.configuration_qwen3_moe import Qwen3MoeConfig
-from typing import Callable, Union
-
-from moe_explore.functional.activation import Activation
 from moe_explore.functional.mlp import (
     moe_mlp_torch, 
     moe_mlp_grouped_gemm_fused,
@@ -19,81 +14,48 @@ from moe_explore.functional.glu import (
     moe_glu_grouped_gemm
 )
 from moe_explore.params import MOEParams
-from moe_explore.testing import random_glu, random_mlp, uniform_weight_init, assert_close
-from moe_explore.hf_moe_reference import qwen3_moe_forward, olmoe_forward
-
-@dataclass
-class MLPInput:
-    input: torch.Tensor
-    router_weight: torch.Tensor
-    weight1: torch.Tensor
-    weight2: torch.Tensor
-
-@dataclass
-class GLUInput:
-    input: torch.Tensor
-    router_weight: torch.Tensor
-    gate_weight: torch.Tensor
-    up_weight: torch.Tensor
-    down_weight: torch.Tensor
-
-@dataclass
-class Params:
-    device: Union[torch.device, str]
-    dtype: torch.dtype
-    seq_len: int
-    input_dim: int
-    hidden_dim: int
-    num_experts: int
-    topk: int
-    activation: Activation
-
-    def random_input(self):
-        return torch.randn((self.seq_len, self.input_dim), device=self.device, dtype=self.dtype)
-
-    def random_params(self, func):
-        return func(
-            self.num_experts,
-            self.input_dim,
-            self.hidden_dim,
-            self.activation,
-            self.device,
-            self.dtype,
-            uniform_weight_init
-        )
-
-    def generate_mlp_inputs(self):
-        return MOEParams(
-            self.random_params(random_mlp),
-            self.num_experts,
-            self.topk
-        )
-
-    def generate_glu_inputs(self):
-        return MOEParams(
-            self.random_params(random_glu),
-            self.num_experts,
-            self.topk
-        )
+from moe_explore.testing import random_glu, random_mlp, random_topk_router, assert_close
         
 test_params = [
-    Params('cuda', torch.float16, 128, 128, 256, num_experts=8, topk=2, activation="gelu"),
-    Params('cuda', torch.float16, 256, 1024, 1024, 8, 2, "gelu"),
-    Params('cuda', torch.float16, 999, 2048, 2048, 8, 2, "gelu"),
-    Params('cuda', torch.bfloat16, 5, 2048, 2048, 8, 2, "gelu"),
-    Params('cuda', torch.float16, 999, 2048, 2048, 64, 8, "gelu"),
-    Params('cuda', torch.float16, 999, 2048, 2048, 64, 8, "gelu"),
-    Params('cuda', torch.float16, 999, 2048, 2048, 64, 8, "silu"),
-    Params('cuda', torch.float16, 2011, 768, 2048, 64, 8, "silu"),
+    (128, 128, 256, "gelu", 8, 2, torch.float16),
+    (256, 1024, 1024, "gelu", 8, 2, torch.float16),
+    (999, 2048, 2048, "gelu", 8, 2, torch.float16),
+    (5, 2048, 2048, "gelu", 8, 2, torch.bfloat16),
+    (999, 2048, 2048, "gelu", 64, 8, torch.float16),
+    (999, 2048, 2048, "gelu", 64, 8, torch.float16),
+    (2011, 2048, 768, "silu", 64, 8, torch.float16),
+    (999, 2048, 2048, "gelu", 64, 8, torch.bfloat16),
+    (999, 2048, 2048, "gelu", 64, 8, torch.bfloat16),
+    (2011, 2048, 768, "silu", 64, 8, torch.bfloat16),
 ]
 
-@pytest.mark.parametrize("params", test_params)
-def test_moe_mlp_grouped_gemm(
-    params
+@pytest.mark.parametrize(
+    "seq_len,input_dim,hidden_dim,activation,num_experts,topk,dtype", test_params)
+def test_moe_mlp(
+    seq_len,
+    input_dim,
+    hidden_dim,
+    activation,
+    num_experts,
+    topk,
+    dtype
 ):
-    input = params.random_input()
-    moe_params = params.generate_mlp_inputs()
-
+    input = torch.randn((seq_len, input_dim), device="cuda", dtype=dtype)
+    moe_params = MOEParams(
+        random_topk_router(
+            num_experts,
+            input_dim,
+            topk,
+            softmax_before_topk=True,
+            normalize_routing=False,
+            device="cuda",
+            dtype=dtype
+        ),
+        random_mlp(num_experts, input_dim, hidden_dim, activation, device="cuda", dtype=dtype),
+        num_experts,
+        topk
+    )
+    
     gg_fused_output = moe_mlp_grouped_gemm_fused(
         input,
         moe_params
@@ -115,12 +77,32 @@ def test_moe_mlp_grouped_gemm(
     assert_close(ref_output, gg_output)
     assert_close(ref_output, gg_fused_output)
 
-@pytest.mark.parametrize("params", test_params)
-def test_moe_glu_grouped_gemm_fused(
-    params
+@pytest.mark.parametrize(
+    "seq_len,input_dim,hidden_dim,activation,num_experts,topk,dtype", test_params)
+def test_moe_glu(
+    seq_len,
+    input_dim,
+    hidden_dim,
+    activation,
+    num_experts,
+    topk,
+    dtype
 ):
-    input = params.random_input()
-    moe_params = params.generate_glu_inputs()
+    input = torch.randn((seq_len, input_dim), device="cuda", dtype=dtype)
+    moe_params = MOEParams(
+        random_topk_router(
+            num_experts,
+            input_dim,
+            topk,
+            softmax_before_topk=True,
+            normalize_routing=False,
+            device="cuda",
+            dtype=dtype
+        ),
+        random_glu(num_experts, input_dim, hidden_dim, activation, device="cuda", dtype=dtype),
+        num_experts,
+        topk
+    )
 
     gg_fused_output = moe_glu_grouped_gemm_fused(
         input,
@@ -133,55 +115,6 @@ def test_moe_glu_grouped_gemm_fused(
     )
 
     ref_output = moe_glu_torch(
-        input,
-        moe_params
-    )
-
-    assert ref_output.isfinite().all()
-    assert gg_output.isfinite().all()
-    assert gg_fused_output.isfinite().all()
-    assert_close(ref_output, gg_output)
-    assert_close(ref_output, gg_fused_output)
-
-@pytest.mark.parametrize(
-    "device,seq_len,input_dim,hidden_dim,Config,forward",
-    [
-        ("cuda", 128, 2048, 1024, OlmoeConfig, olmoe_forward),
-        ("cuda", 128, 1024, 768, Qwen3MoeConfig, qwen3_moe_forward)
-    ])
-def test_huggingface(device, seq_len, input_dim, hidden_dim, Config, forward):
-
-    config = Config(
-       hidden_size=input_dim,
-       intermediate_size=hidden_dim,
-    )
-
-    params = Params(
-        device,
-        torch.bfloat16,
-        seq_len,
-        input_dim,
-        hidden_dim,
-        config.num_experts,
-        config.num_experts_per_tok,
-        "silu"
-    )
-
-    input = params.random_input()
-    moe_params = params.generate_glu_inputs()
-
-    ref_output = forward(
-        config,
-        input.unsqueeze(0),
-        moe_params
-    ).squeeze(0)    
-
-    gg_output = moe_glu_grouped_gemm(
-        input,
-        moe_params
-    )
-
-    gg_fused_output = moe_glu_grouped_gemm_fused(
         input,
         moe_params
     )

--- a/tests/test_hf.py
+++ b/tests/test_hf.py
@@ -1,0 +1,84 @@
+import torch
+import pytest
+import numpy as np
+from moe_explore.hf_moe_reference import olmoe_forward, qwen3_moe_forward, ernie4_5_moe_forward
+from moe_explore.functional.glu import moe_glu_grouped_gemm, moe_glu_grouped_gemm_fused
+from transformers import AutoConfig
+from moe_explore.params import MOEParams
+from moe_explore.testing import random_glu, random_topk_router, random_ernie_router, assert_close
+
+OLMOE = "allenai/OLMoE-1B-7B-0924"
+QWEN3 = "Qwen/Qwen3-30B-A3B"
+ERNIE4 = "baidu/ERNIE-4.5-21B-A3B-Base-PT"
+
+def hf_config_to_moe_params(config, model_name):
+    expert_params = random_glu(
+        config.num_experts,
+        config.hidden_size,
+        config.intermediate_size,
+        config.hidden_act,
+        "cuda",
+        torch.bfloat16
+    )    
+    if model_name in (OLMOE, QWEN3):
+        return MOEParams(
+            router_params=random_topk_router(
+                config.num_experts,
+                config.hidden_size,
+                config.num_experts_per_tok,
+                softmax_before_topk=True,
+                normalize_routing=config.norm_topk_prob,
+                device="cuda",
+                dtype=torch.bfloat16
+            ),
+            expert_params=expert_params,
+            num_experts=config.num_experts,
+            topk=config.num_experts_per_tok,
+        )
+    if model_name == ERNIE4:
+        return MOEParams(
+            router_params=random_ernie_router(
+                config.moe_num_experts,
+                config.hidden_size,
+                config.moe_k,
+                "cuda",
+                torch.bfloat16
+            ),
+            expert_params=expert_params,
+            num_experts=config.moe_num_experts,
+            topk=config.moe_k,
+        )
+
+@pytest.mark.parametrize(
+    "seq_len,model_name,forward",
+    [
+        (128, OLMOE, olmoe_forward),
+        (128, QWEN3, qwen3_moe_forward),
+        (128, ERNIE4, ernie4_5_moe_forward)
+    ])
+def test_huggingface(seq_len, model_name, forward):
+    config = AutoConfig.from_pretrained(model_name)
+    moe_params = hf_config_to_moe_params(config, model_name=model_name)
+    input = torch.randn((seq_len, config.hidden_size), device="cuda", dtype=torch.bfloat16)
+
+    ref_output = forward(
+        config,
+        input.unsqueeze(0),
+        moe_params
+    ).squeeze(0)    
+
+    gg_output = moe_glu_grouped_gemm(
+        input,
+        moe_params
+    )
+
+    gg_fused_output = moe_glu_grouped_gemm_fused(
+        input,
+        moe_params
+    )
+
+    assert ref_output.isfinite().all()
+    assert gg_output.isfinite().all()
+    assert gg_fused_output.isfinite().all()
+    assert_close(ref_output, gg_output)
+    assert_close(ref_output, gg_fused_output)


### PR DESCRIPTION
- uses a different style of router, so this generalizes the functional APIs some to support different router parameters.
- cleans up the tests significantly.